### PR TITLE
Several fixes for CMakeLists.txt of matlab

### DIFF
--- a/src/matlab/CMakeLists.txt
+++ b/src/matlab/CMakeLists.txt
@@ -1,8 +1,4 @@
-#IF(WIN32)
-#    SET(MEXEXT_CMD cmd /C mexext)
-#ELSE(WIN32)
-#    SET(MEXEXT_CMD mexext)
-#ENDIF(WIN32)
+cmake_minimum_required(VERSION 3.7)
 
 SET(MEX_NAME nearest_neighbors)
 
@@ -16,19 +12,32 @@ endif()
 
 find_program(OCT_CMD mkoctfile)
 
-get_property(FLANN_LIB_LOCATION TARGET flann_s PROPERTY LOCATION)
-get_filename_component(FLANN_LIB_PATH ${FLANN_LIB_LOCATION} PATH)
+if (TARGET flann_s)
+    get_property(FLANN_LIB_LOCATION TARGET flann_s PROPERTY LOCATION)
+endif()
+get_filename_component(FLANN_LIB_PATH ${FLANN_LIB_LOCATION} REALPATH) 
+if (NOT IS_DIRECTORY FLANN_LIB_PATH)
+    set(FLANN_LIB_LOCATION ${FLANN_LIB_PATH})
+    get_filename_component(FLANN_LIB_PATH ${FLANN_LIB_LOCATION} PATH)
+endif()
+
+if (PROJECT_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(ARG_INCLUDE_DIR0 "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+else()
+    set(ARG_INCLUDE_DIR0 "${PROJECT_SOURCE_DIR}")
+endif()
+get_filename_component(ARG_INCLUDE_DIR ${ARG_INCLUDE_DIR0} REALPATH)
 
 if(MEX_CMD AND MEXEXT_CMD)
 
-    get_filename_component(MEX_REAL_CMD ${MEX_CMD} ABSOLUTE)
+    get_filename_component(MEX_REAL_CMD ${MEX_CMD} REALPATH)
     get_filename_component(MEX_PATH ${MEX_REAL_CMD} PATH)
 
-    get_filename_component(MEXEXT_REAL_CMD ${MEXEXT_CMD} ABSOLUTE)
+    get_filename_component(MEXEXT_REAL_CMD ${MEXEXT_CMD} REALPATH)
     get_filename_component(MEXEXT_PATH ${MEXEXT_REAL_CMD} PATH)
 
     if (MEX_PATH STREQUAL MEXEXT_PATH)
-        message(STATUS "Found MATLAB at: " ${MEX_PATH})
+        message(STATUS "Found MATLAB at: ${MEX_PATH}")
 
         EXECUTE_PROCESS(COMMAND ${MEXEXT_REAL_CMD} OUTPUT_VARIABLE MEX_EXTENSION OUTPUT_STRIP_TRAILING_WHITESPACE)
         SET(MEX_FILE ${CMAKE_CURRENT_BINARY_DIR}/${MEX_NAME}.${MEX_EXTENSION})
@@ -44,12 +53,11 @@ if(MEX_CMD AND MEXEXT_CMD)
             set(MEX_BUILD_FLAGS "CFLAGS='$$CFLAGS ${OpenMP_CXX_FLAGS}' LDFLAGS='$$LDFLAGS ${OpenMP_CXX_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}'")
         endif()
         separate_arguments(MEX_BUILD_FLAGS)   
-
         ADD_CUSTOM_COMMAND(
             OUTPUT ${MEX_FILE}
             COMMAND ${MEX_REAL_CMD}
-            ARGS ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp -I${PROJECT_SOURCE_DIR}/src/cpp -L${FLANN_LIB_PATH} -lflann_s ${MEX_BUILD_FLAGS}
-            DEPENDS flann_s ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp
+            ARGS ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp -I${ARG_INCLUDE_DIR}/src/cpp -L${FLANN_LIB_PATH} -lflann_s ${MEX_BUILD_FLAGS} -lgomp
+            DEPENDS ${FLANN_LIB_PATH}/libflann_s.a ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp
             COMMENT "Building MEX extension ${MEX_FILE}"
         )
 
@@ -66,22 +74,22 @@ if(MEX_CMD AND MEXEXT_CMD)
         set(BUILD_MATLAB_BINDINGS OFF) 
     endif()
 elseif(OCT_CMD)
-  SET(MEX_FILE ${CMAKE_CURRENT_BINARY_DIR}/${MEX_NAME}.mex)
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${MEX_FILE}
-    COMMAND ${OCT_CMD}
-    ARGS ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp -I${PROJECT_SOURCE_DIR}/src/cpp -L${FLANN_LIB_PATH} -DFLANN_STATIC -lflann_s -lgomp --mex
-    DEPENDS flann_s ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp
-    COMMENT "Building MEX extension ${MEX_FILE}"
+    SET(MEX_FILE ${CMAKE_CURRENT_BINARY_DIR}/${MEX_NAME}.mex)
+    ADD_CUSTOM_COMMAND(
+        OUTPUT ${MEX_FILE}
+        COMMAND ${OCT_CMD}
+        ARGS ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp -I${ARG_INCLUDE_DIR}/src/cpp -L${FLANN_LIB_PATH} -DFLANN_STATIC -lflann_s -lgomp --mex
+        DEPENDS ${FLANN_LIB_PATH}/libflann_s.a ${CMAKE_CURRENT_SOURCE_DIR}/${MEX_NAME}.cpp
+        COMMENT "Building MEX extension ${MEX_FILE}"
     )
 
-  ADD_CUSTOM_TARGET(mex_${MEX_NAME} ALL DEPENDS ${MEX_FILE})
+    ADD_CUSTOM_TARGET(mex_${MEX_NAME} ALL DEPENDS ${MEX_FILE})
 
-  FILE(GLOB MATLAB_SOURCES *.m)
+    FILE(GLOB MATLAB_SOURCES *.m)
 
-  INSTALL (
-    FILES ${MEX_FILE} ${MATLAB_SOURCES}
-    DESTINATION share/flann/octave
+    INSTALL (
+        FILES ${MEX_FILE} ${MATLAB_SOURCES}
+        DESTINATION share/flann/octave
     )
 else()
     message(WARNING "Cannot find MATLAB or Octave instalation. Make sure that the 'bin' directory from the MATLAB instalation or that mkoctfile is in PATH")


### PR DESCRIPTION
Important fixes:
1. Enable executing the CMakeLists.txt from the directory of ./src/matlab:
1.A. Avoid looking for flann_s location if target does not exists
1.B. passing -DFLANN_LIB_LOCATION=${HOME}/flann/lib/libflann_s.a in the cmake command line and using it as default search path
1.C. Using a new veriable: ARG_INCLUDE_DIR which is passed as an argument to the mex. Its value depends on the original directory which the cmake is called.

2. Fixing linker problems:
2.A. Add FLANN_LIB_PATH as an argument for the DEPENDS property
2.B. Add -lgomp as an additional argument to the mex to resolve missing symbols

3. Dealing with the "missing matlab" error where the symbolic link for the mex tool located in /usr/local/bin and the mexext does not have a symbolic link and is located in the original directory of the matlab installation.
3.A. Working with REALPATH instead of ABSOLUTE in order to overcome this symbolic link problem.

Minor fixes:
4. Removing commented out source lines
5. Indentation
6. Overcoming warnings of using minimum version of cmake